### PR TITLE
Fixed Environment Detection

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,9 +39,8 @@ app.use(express.urlencoded({ extended: false}))
 /*
 Environment Configuration
 */
-
-if (process.env.NODE_ENV == 'development') {
-    var config = require('./config')
+var config = require('./config')
+if (config) {
     var DATABASE_CREDENTIALS = config.LOCAL_DATABASE_CREDENTIALS
     process.env.PORT = 8080
 } else if (process.env.NODE_ENV == 'production') {


### PR DESCRIPTION
Change will check for a config file, if it comes back undefined, it assumes its running on Heroku and launches as production.

Since there is no config file on Heroku, this works. However, if there is a config file (which is the case on the local machine for each of us) it will run as development.

This will allow us to continue running `node app.js` with no extras on our local machine, but allow the correct environment to be selected.