### PR TITLE
Handlebars nav

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,7 @@ app.get('/', function(req, res) {
         results.forEach(element => {
             data += element.first_name + ' '
         });
-        res.render('home', {data: data})    
+        res.render('home', {data: data, dashboard: 1})    
     }
     })
     
@@ -95,7 +95,7 @@ app.get('/product_catalog', function(req, res) {
             res.send('Error loading product_catalog: ' + error)
         } else {
             console.log(results)
-            res.render('product_catalog', {sqlResults: results})
+            res.render('product_catalog', {sqlResults: results, product_catalog: 1})
         }
     })
 })
@@ -165,7 +165,7 @@ app.get('/inventory', function(req, res) {
           res.render('inventory', {data:data})
         }
 
-        console.log(results)
+        // console.log({results: results, inventory: 1})
 
         // Check for not active item
         results.forEach(function(value, index) {
@@ -195,7 +195,7 @@ app.get('/inventory', function(req, res) {
         })
 
         // Send the data to the inventory template
-        res.render('inventory', results)
+        res.render('inventory', {results: results, inventory: 1})
     })
   })
 

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -1,18 +1,3 @@
-{{!-- Navbar --}}
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="/">Apple Cart</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-        <div class="navbar-nav">
-            <a class="nav-item nav-link active" href="/">Home <span class="sr-only">(current)</span></a>
-            <a class="nav-item nav-link" href="product_catalog">Product Catalog</a>
-            <a class="nav-item nav-link" href="inventory">Manage Inventory</a>
-        </div>
-    </div>
-</nav>
-
 {{!-- Content --}}
 <div class="mt-4 container-fluid">
     <h1 class="display-4 text-center">The Apple Cart</h1>

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -21,7 +21,7 @@
                   <div class="col">
                       <label for="product_name_input">Product Name</label>
                       <select class="form-control" id="product_name_input" name="product_name_input">
-                          {{#each results}
+                          {{#each results}}
                           {{#if active}}
                           <option>{{name}}</option>
                           {{/if}}

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -21,7 +21,7 @@
                   <div class="col">
                       <label for="product_name_input">Product Name</label>
                       <select class="form-control" id="product_name_input" name="product_name_input">
-                          {{#each this}}
+                          {{#each results}
                           {{#if active}}
                           <option>{{name}}</option>
                           {{/if}}

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -1,18 +1,3 @@
-{{!-- Navbar --}}
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="/">Apple Cart</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-        <div class="navbar-nav">
-            <a class="nav-item nav-link" href="/">Home</a>
-            <a class="nav-item nav-link" href="product_catalog">Product Catalog</a>
-            <a class="nav-item nav-link active" href="inventory">Manage Inventory<span class="sr-only">(current)</span></a>
-        </div>
-    </div>
-</nav>
-
 {{!-- Content --}}
 <div class="mt-4 container-fluid">
 
@@ -77,7 +62,7 @@
                   <div class="col">
                       <label for="product_name_input">Product Name</label>
                       <select class="form-control" id="product_name_input" name="product_name_input">
-                          {{#each this}}
+                          {{#each results}}
                           {{#if name}}
                           <option>{{name}}</option>
                           {{/if}}
@@ -129,7 +114,7 @@
         </tr>
       </thead>
       <tbody>
-        {{#each this}}
+        {{#each results}}
           {{#if name}}
             {{#if not_catalog}}
             <tr>

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -11,6 +11,20 @@
     <title>The Apple Cart</title>
 </head>
 <body>
+    {{!-- Navbar --}}
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <a class="navbar-brand" href="/">Apple Cart</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+            <div class="navbar-nav">
+                <a class="nav-item nav-link {{#if dashboard}} active {{/if}}" href="/">Dashboard{{#if dashboard}}<span class="sr-only">(current)</span>{{/if}}</a>
+                <a class="nav-item nav-link {{#if product_catalog}} active {{/if}}" href="product_catalog">Product Catalog{{#if product_catalog}}<span class="sr-only">(current)</span>{{/if}}</a>
+                <a class="nav-item nav-link {{#if inventory}} active {{/if}}" href="inventory">Manage Inventory{{#if inventory}}<span class="sr-only">(current)</span>{{/if}}</a>
+            </div>
+        </div>
+    </nav>
     {{{body}}}
 
      <!-- Bootstrap - jQuery first, then Popper.js, then Bootstrap JS -->

--- a/views/product_catalog.hbs
+++ b/views/product_catalog.hbs
@@ -1,5 +1,5 @@
 {{!-- Content --}}
-=======
+
 {{!-- Table --}}
 
 <div class="mt-4 container-fluid">

--- a/views/product_catalog.hbs
+++ b/views/product_catalog.hbs
@@ -1,6 +1,5 @@
 {{!-- Content --}}
 
-{{!-- Table --}}
 
 <div class="mt-4 container-fluid">
 

--- a/views/product_catalog.hbs
+++ b/views/product_catalog.hbs
@@ -1,20 +1,7 @@
-{{!-- Navbar --}}
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="/">Apple Cart</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-        <div class="navbar-nav">
-            <a class="nav-item nav-link" href="/">Home</a>
-            <a class="nav-item nav-link active" href="product_catalog">Product Catalog<span class="sr-only">(current)</span></a>
-            <a class="nav-item nav-link" href="inventory">Manage Inventory</a>
-        </div>
-    </div>
-</nav>
-
-
 {{!-- Content --}}
+=======
+{{!-- Table --}}
+
 <div class="mt-4 container-fluid">
 
   {{!-- Product Catalog Management Forms --}}


### PR DESCRIPTION
1.) Moved the navbar into the handlebars main template.
2.) Removed the navbar from all other templates
3.) Tweaked the git get request code for inventory to stay consistent with the get request for home and product_catalog
    - Simply changed req.response("inventory", results) to req.response("inventory", {results: results}) and changed minor code in the inventory.hbs from (#each this) to (#each results)
4.) Added a single tuple to each get request response to indicate which page is currently active.
5.) Changed home back to dashboard how we had prior to the new navbar. I had accidentally renamed it to home, and felt dashboard was more of a business term.