### PR TITLE
User Story: Set Capacity for Shelves

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ As long as you do not get any errors, you should be able to open up your browser
 - The ClearDB (MySQL) database credentials are stored in process.env.CLEARDB_DATABASE_URL
 - All static assets such as pictures, icons, JS files, and stylesheets can be stored in ./public and the path to those assets can be referred to in HTML as './css/example.css' or './img/apple_cart.jpg' as examples.
 - When writing SQL queries, use the following convention to avoid possible conflicts down the road: (1) table and attribute references are all lowercase (2) SQL commands and reserved words are all caps. Ex: `SELECT first_name, last_name FROM users WHERE id = 1`
+- New Convention: When creating new classes for use, prefix them with 'gt_' or 'gt-' so that our team knows this was a class created by one of us. GT stands for Globetrotters! This helps differentiate between standard Bootstrap classes.
 
 ## Github Best Practices
 

--- a/app.js
+++ b/app.js
@@ -256,8 +256,7 @@ app.post('/inventory/modify_item', function(req, res) {
     var max = req.body.modal_shelf_maximum_threshold
     
     // Form the SQL Query needed to update the shelf thresholds
-    var mod_inventory_query_string = "UPDATE products SET shelf_min_threshold = " +
-    min + ", shelf_max_threshold = " + max + " WHERE id = " + id
+    var mod_inventory_query_string = `UPDATE products SET shelf_min_threshold='${min}', shelf_max_threshold='${max}' WHERE id='${id}'`
 
     // Send the query, if it fails, log to console, if it succeeds, update the row and refresh the data on the screen.
     connection.query(mod_inventory_query_string, function(error, results, fields) {

--- a/app.js
+++ b/app.js
@@ -251,9 +251,9 @@ app.post('/inventory/remove_item', function (req, res) {
 app.post('/inventory/modify_item', function(req, res) {
     
     // Grab the necessary data from the POST request body
-    var id = req.body.modal_shelf_id;
-    var min = req.body.modal_shelf_minimum_threshold
-    var max = req.body.modal_shelf_maximum_threshold
+    const id = req.body.modal_shelf_id;
+    const min = req.body.modal_shelf_minimum_threshold
+    const max = req.body.modal_shelf_maximum_threshold
     
     // Form the SQL Query needed to update the shelf thresholds
     var mod_inventory_query_string = `UPDATE products SET shelf_min_threshold='${min}', shelf_max_threshold='${max}' WHERE id='${id}'`

--- a/app.js
+++ b/app.js
@@ -257,7 +257,10 @@ app.post('/inventory/modify_item', function(req, res) {
     
     // Form the SQL Query needed to update the shelf thresholds
     var mod_inventory_query_string = "UPDATE products SET shelf_min_threshold = " +
-    min + ", shelf_max_threshold = " + max + "WHERE id = " + id
+    min + ", shelf_max_threshold = " + max + " WHERE id = " + id
+
+    // DEBUG
+    console.log(mod_inventory_query_string)
 
     // Send the query, if it fails, log to console, if it succeeds, update the row and refresh the data on the screen.
     connection.query(mod_inventory_query_string, function(error, results, fields) {

--- a/app.js
+++ b/app.js
@@ -259,9 +259,6 @@ app.post('/inventory/modify_item', function(req, res) {
     var mod_inventory_query_string = "UPDATE products SET shelf_min_threshold = " +
     min + ", shelf_max_threshold = " + max + " WHERE id = " + id
 
-    // DEBUG
-    console.log(mod_inventory_query_string)
-
     // Send the query, if it fails, log to console, if it succeeds, update the row and refresh the data on the screen.
     connection.query(mod_inventory_query_string, function(error, results, fields) {
         if (error) {

--- a/app.js
+++ b/app.js
@@ -247,6 +247,28 @@ app.post('/inventory/remove_item', function (req, res) {
     })
 })
 
+// Inventory - Modify Item Route
+app.post('/inventory/modify_item', function(req, res) {
+    
+    // Grab the necessary data from the POST request body
+    var id = req.body.modal_shelf_id;
+    var min = req.body.modal_shelf_minimum_threshold
+    var max = req.body.modal_shelf_maximum_threshold
+    
+    // Form the SQL Query needed to update the shelf thresholds
+    var mod_inventory_query_string = "UPDATE products SET shelf_min_threshold = " +
+    min + ", shelf_max_threshold = " + max + "WHERE id = " + id
+
+    // Send the query, if it fails, log to console, if it succeeds, update the row and refresh the data on the screen.
+    connection.query(mod_inventory_query_string, function(error, results, fields) {
+        if (error) {
+            console.log("Modify item in inventory failed...\n" + error)
+        } else {
+            res.redirect('/inventory')
+        }
+    })
+})
+
 /*
 Listener
 */

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -41,7 +41,7 @@ form.addEventListener('submit', function(event) {
     var input_min = form.querySelector('#modal_shelf_minimum_threshold')
     var input_max = form.querySelector('#modal_shelf_maximum_threshold')
     console.log (input_min.value, input_max.value, input_min.value > input_max.value)
-    if (input_min.value > input_max.value) {
+    if (parseInt(input_min.value) > parseInt(input_max.value)) {
         input_min.classList.add("is-invalid")
         input_max.classList.add("is-invalid")
         event.preventDefault();

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -64,9 +64,13 @@ form.addEventListener('submit', function(event) {
 })
 
 function form_shelves_check_min() {
-    if (input_min.value > input_max.value) {
-        return false
-    } else {
-        return true
+    var form = document.getElementsByClassName('needs-validation')[0]
+    var input_min = document.querySelector('#modal_shelf_minimum_threshold')
+    var input_max = document.querySelector('#modal_shelf_maximum_threshold')
+
+    if (input_max.value < input_min.value) {
+        form.setCustomValidity("The shelf maximum must be greater than or equal to the shelf minimum.")
+        return
     }
+    form.setCustomValidity("");
 }

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -15,13 +15,18 @@ for (var row of shelf_row) {
             // Get the current values from the table on the screen.
             var min = row.querySelector('.gt_shelf_min_threshold').innerHTML
             var max = row.querySelector('.gt_shelf_max_threshold').innerHTML
+            var id = row.querySelector('.gt_shelf_id').innerHTML
             console.log(min, max)
             
-            // Populate the modal with the current values
+            // Populate the modal with the current values.
             var modal_input_min = document.querySelector('#modal_shelf_minimum_threshold')
             var modal_input_max = document.querySelector('#modal_shelf_maximum_threshold')
+            var modal_input_id = document.querySelector('#modal_shelf_id')
             modal_input_min.value = min
             modal_input_max.value = max
+            modal_input_id.value = id
+
+            // Make the modal appear.
             $("#shelvesEditModal").modal("show")
         })
     }(row))

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -1,0 +1,25 @@
+/*
+shelves_edit.js
+Author: George Kochera
+Description: Enables the ability to click on a row in the inventory page and edit the shelves capacity.
+*/
+
+// Find all the items on the page.
+var shelf_row = document.getElementsByClassName('gt_product')
+
+// Add event listeners to all the rows so when we click on them, they open a modal.
+for (var row of shelf_row) {
+    (function (row){
+        row.addEventListener('click', function(){
+            
+            // Get the current values from the table on the screen.
+            var min = row.querySelector('.gt_shelf_min_threshold').innerHTML
+            var max = row.querySelector('.gt_shelf_max_threshold').innerHTML
+            console.log(min, max)
+            
+            // Populate the modal with the current values
+            var 
+            $("#shelvesEditModal").modal("show")
+        })
+    }(row))
+}

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -18,7 +18,10 @@ for (var row of shelf_row) {
             console.log(min, max)
             
             // Populate the modal with the current values
-            var 
+            var modal_input_min = document.querySelector('#modal_shelf_minimum_threshold')
+            var modal_input_max = document.querySelector('#modal_shelf_maximum_threshold')
+            modal_input_min.value = min
+            modal_input_max.value = max
             $("#shelvesEditModal").modal("show")
         })
     }(row))

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -55,22 +55,16 @@ var form = document.getElementsByClassName('needs-validation')[0]
 var input_min = document.querySelector('#modal_shelf_minimum_threshold').value
 var input_max = document.querySelector('#modal_shelf_maximum_threshold').value
 
+console.log(form)
+
 form.addEventListener('submit', function(event) {
-        if (form.checkValidity()) {
-            event.preventDefault();
-            event.stopPropagation();
-        }
-        form.classList.add('was-validated')
-})
-
-function form_shelves_check_min() {
     var form = document.getElementsByClassName('needs-validation')[0]
-    var input_min = document.querySelector('#modal_shelf_minimum_threshold')
-    var input_max = document.querySelector('#modal_shelf_maximum_threshold')
-
-    if (input_max.value < input_min.value) {
-        form.setCustomValidity("The shelf maximum must be greater than or equal to the shelf minimum.")
-        return
+    var input_min = form.querySelector('#modal_shelf_minimum_threshold')
+    var input_max = form.querySelector('#modal_shelf_maximum_threshold')
+    if (input_min.value > input_max.value) {
+        input_min.classList.add("is-invalid")
+        input_max.classList.add("is-invalid")
+        event.preventDefault();
+        event.stopPropagation();
     }
-    form.setCustomValidity("");
-}
+})

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -33,3 +33,40 @@ for (var row of shelf_row) {
 }
 
 // TODO: Data Validation
+// (function() {
+//     window.addEventListener('load', function() {
+//         var forms = document.getElementsByClassName('needs-validation')
+
+//         var validation = Array.prototype.filter.call(forms, function(form) {
+//             form.addEventListener('submit', function(event) {
+//                 var modal_input_min = document.querySelector('#modal_shelf_minimum_threshold').value
+//                 var modal_input_max = document.querySelector('#modal_shelf_maximum_threshold').value
+//                 if (modal_input_max < modal_input_min || modal_input_min > modal_input_max) {
+//                     event.preventDefault();
+//                     event.stopPropagation();
+//                 }
+//                 form.classList.add('was-validated')
+//             }, false);
+//         });
+//     }, false)
+// })()
+
+var form = document.getElementsByClassName('needs-validation')[0]
+var input_min = document.querySelector('#modal_shelf_minimum_threshold').value
+var input_max = document.querySelector('#modal_shelf_maximum_threshold').value
+
+form.addEventListener('submit', function(event) {
+        if (form.checkValidity()) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        form.classList.add('was-validated')
+})
+
+function form_shelves_check_min() {
+    if (input_min.value > input_max.value) {
+        return false
+    } else {
+        return true
+    }
+}

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -35,10 +35,12 @@ for (var row of shelf_row) {
 
 // Add event listener to the form so that only valid input can be given. This enforces the minimum shelf value must be greater
 // than the maximum shelf value.
+var form = document.getElementsByClassName('needs-validation')[0]
+
 form.addEventListener('submit', function(event) {
-    var form = document.getElementsByClassName('needs-validation')[0]
     var input_min = form.querySelector('#modal_shelf_minimum_threshold')
     var input_max = form.querySelector('#modal_shelf_maximum_threshold')
+    console.log (input_min.value, input_max.value, input_min.value > input_max.value)
     if (input_min.value > input_max.value) {
         input_min.classList.add("is-invalid")
         input_max.classList.add("is-invalid")

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -4,7 +4,7 @@ Author: George Kochera
 Description: Enables the ability to click on a row in the inventory page and edit the shelves capacity.
 */
 
-// Find all the items on the page.
+// Find all the product rows on the page.
 var shelf_row = document.getElementsByClassName('gt_product')
 
 // Add event listeners to all the rows so when we click on them, they open a modal.
@@ -31,3 +31,5 @@ for (var row of shelf_row) {
         })
     }(row))
 }
+
+// TODO: Data Validation

--- a/public/scripts/shelves_edit.js
+++ b/public/scripts/shelves_edit.js
@@ -1,7 +1,8 @@
 /*
 shelves_edit.js
 Author: George Kochera
-Description: Enables the ability to click on a row in the inventory page and edit the shelves capacity.
+Description: Enables the ability to click on a row in the inventory page and edit the shelves capacity. Data validation
+is enforced in the modal. The only rule is that the maximum must be greater than or equal to the minimum value.
 */
 
 // Find all the product rows on the page.
@@ -32,31 +33,8 @@ for (var row of shelf_row) {
     }(row))
 }
 
-// TODO: Data Validation
-// (function() {
-//     window.addEventListener('load', function() {
-//         var forms = document.getElementsByClassName('needs-validation')
-
-//         var validation = Array.prototype.filter.call(forms, function(form) {
-//             form.addEventListener('submit', function(event) {
-//                 var modal_input_min = document.querySelector('#modal_shelf_minimum_threshold').value
-//                 var modal_input_max = document.querySelector('#modal_shelf_maximum_threshold').value
-//                 if (modal_input_max < modal_input_min || modal_input_min > modal_input_max) {
-//                     event.preventDefault();
-//                     event.stopPropagation();
-//                 }
-//                 form.classList.add('was-validated')
-//             }, false);
-//         });
-//     }, false)
-// })()
-
-var form = document.getElementsByClassName('needs-validation')[0]
-var input_min = document.querySelector('#modal_shelf_minimum_threshold').value
-var input_max = document.querySelector('#modal_shelf_maximum_threshold').value
-
-console.log(form)
-
+// Add event listener to the form so that only valid input can be given. This enforces the minimum shelf value must be greater
+// than the maximum shelf value.
 form.addEventListener('submit', function(event) {
     var form = document.getElementsByClassName('needs-validation')[0]
     var input_min = form.querySelector('#modal_shelf_minimum_threshold')

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -132,7 +132,7 @@
         {{#each this}}
           {{#if name}}
             {{#if not_catalog}}
-            <tr>
+            <tr class="gt_product">
               <td class="text-center bg-secondary">{{id}}</td>
               <td class="text-center bg-secondary">{{name}}</td>
               <td class="text-center bg-secondary">{{total_quantity}}</td>
@@ -141,11 +141,11 @@
               <td class="text-center bg-secondary">{{wh_min_threshold}}</td>
               <td class="text-center bg-secondary">{{wh_max_threshold}}</td>
               <td class="text-center bg-secondary">{{shelf_quantity}}</td>
-              <td class="text-center bg-secondary">{{shelf_min_threshold}}</td>
-              <td class="text-center bg-secondary">{{shelf_max_threshold}}</td>
+              <td class="text-center bg-secondary gt_shelf_min_threshold">{{shelf_min_threshold}}</td>
+              <td class="text-center bg-secondary gt_shelf_max_threshold">{{shelf_max_threshold}}</td>
             </tr>
             {{else}}
-            <tr>
+            <tr class="gt_product">
               <td class="text-center">{{id}}</td>
               <td class="text-center">{{name}}</td>
               <td class="text-center">{{total_quantity}}</td>
@@ -162,8 +162,8 @@
               {{else}}
               <td class="text-center">{{shelf_quantity}}</td>
               {{/if}}
-              <td class="text-center">{{shelf_min_threshold}}</td>
-              <td class="text-center">{{shelf_max_threshold}}</td>
+              <td class="text-center gt_shelf_min_threshold">{{shelf_min_threshold}}</td>
+              <td class="text-center gt_shelf_max_threshold">{{shelf_max_threshold}}</td>
             </tr>
             {{/if}}
           {{/if}}

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -172,3 +172,6 @@
     </table>
   </div>
 </div>
+
+{{!-- Modal (Popup To Edit Shelves Thresholds) --}}
+{{> shelves_edit_modal}}

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -133,7 +133,7 @@
           {{#if name}}
             {{#if not_catalog}}
             <tr class="gt_product">
-              <td class="text-center bg-secondary">{{id}}</td>
+              <td class="text-center bg-secondary gt_shelf_id">{{id}}</td>
               <td class="text-center bg-secondary">{{name}}</td>
               <td class="text-center bg-secondary">{{total_quantity}}</td>
               <td class="text-center bg-secondary">{{exp_date}}</td>
@@ -146,7 +146,7 @@
             </tr>
             {{else}}
             <tr class="gt_product">
-              <td class="text-center">{{id}}</td>
+              <td class="text-center gt_shelf_id">{{id}}</td>
               <td class="text-center">{{name}}</td>
               <td class="text-center">{{total_quantity}}</td>
               <td class="text-center">{{exp_date}}</td>

--- a/views/inventory.hbs
+++ b/views/inventory.hbs
@@ -22,6 +22,7 @@
         <h1 class="display-4 text-left">Inventory</h1>
         <p class="text-left">Low Shelf Inventory appears in<span class="text-danger"> red</span>.</p>
         <p class="text-left">Inactive items appears in<span class="text-secondary"> gray</span>.</p>
+        <p class="text-left">Users can click on the row to adjust shelf thresholds.</p>
     </div>
   </div>
 

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <form class="needs-validation" action="/inventory/modify_item" method="POST" id="modal_shelf">
+        <form class="needs-validation" action="/inventory/modify_item" method="POST" id="modal_shelf" novalidate>
             Shelf Thresholds:
           <div class="form-group">
             <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <form>
+        <form action="/inventory/modify_item" method="POST" id="modal_shelf">
             Shelf Thresholds:
           <div class="form-group">
             <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>
@@ -25,7 +25,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="submit" class="btn btn-primary" form="modal_shelf">Save changes</button>
       </div>
     </div>
   </div>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -1,0 +1,28 @@
+<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <form>
+          <div class="form-group">
+            <label for="recipient-name" class="col-form-label">Recipient:</label>
+            <input type="text" class="form-control" id="recipient-name">
+          </div>
+          <div class="form-group">
+            <label for="message-text" class="col-form-label">Message:</label>
+            <textarea class="form-control" id="message-text"></textarea>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -8,15 +8,21 @@
         </button>
       </div>
       <div class="modal-body">
-        <form action="/inventory/modify_item" method="POST" id="modal_shelf">
+        <form class="needs-validation" action="/inventory/modify_item" method="POST" id="modal_shelf">
             Shelf Thresholds:
           <div class="form-group">
             <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>
-            <input type="number" class="form-control" id="modal_shelf_minimum_threshold" name="modal_shelf_minimum_threshold">
+            <input type="number" class="form-control" min='0'id="modal_shelf_minimum_threshold" name="modal_shelf_minimum_threshold">
+            <div class="invalid-feedback">
+              Shelf minimum must be less than or equal to shelf maximum.
+            </div>
           </div>
           <div class="form-group">
             <label for="modal_shelf_maximum_threshold" class="col-form-label">Maximum:</label>
-            <input type="number" class="form-control" id="modal_shelf_maximum_threshold" name="modal_shelf_maximum_threshold">
+            <input type="number" class="form-control" min='0' id="modal_shelf_maximum_threshold" name="modal_shelf_maximum_threshold">
+            <div class="invalid-feedback">
+              Shelf maximum must be more than or equal to shelf minimum.
+            </div>
           </div>
           <div class="form-group">
             <input type="hidden" class="form-control" id="modal_shelf_id" name="modal_shelf_id">

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -8,14 +8,11 @@
         </button>
       </div>
       <div class="modal-body">
-        <form class="needs-validation" action="/inventory/modify_item" method="POST" id="modal_shelf" novalidate>
+        <form class="needs-validation" action="/inventory/modify_item" method="POST" id="modal_shelf">
             Shelf Thresholds:
           <div class="form-group">
             <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>
             <input type="number" class="form-control" min='0'id="modal_shelf_minimum_threshold" name="modal_shelf_minimum_threshold">
-            <div class="invalid-feedback">
-              Shelf minimum must be less than or equal to shelf maximum.
-            </div>
           </div>
           <div class="form-group">
             <label for="modal_shelf_maximum_threshold" class="col-form-label">Maximum:</label>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -11,12 +11,12 @@
         <form>
             Shelf Thresholds:
           <div class="form-group">
-            <label for="shelf_minimum_threshold" class="col-form-label">Minimum:</label>
-            <input type="number" class="form-control" id="shelf_minimum_threshold">
+            <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>
+            <input type="number" class="form-control" id="modal_shelf_minimum_threshold">
           </div>
           <div class="form-group">
-            <label for="shelf_maximum_threshold" class="col-form-label">Maximum:</label>
-            <input type="number" class="form-control" id="shelf_maximum_threshold">
+            <label for="modal_shelf_maximum_threshold" class="col-form-label">Maximum:</label>
+            <input type="number" class="form-control" id="modal_shelf_maximum_threshold">
           </div>
         </form>
       </div>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -18,6 +18,9 @@
             <label for="modal_shelf_maximum_threshold" class="col-form-label">Maximum:</label>
             <input type="number" class="form-control" id="modal_shelf_maximum_threshold">
           </div>
+          <div class="form-group">
+            <input type="hidden" class="form-control" id="modal_shelf_id">
+          </div>
         </form>
       </div>
       <div class="modal-footer">

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -12,14 +12,14 @@
             Shelf Thresholds:
           <div class="form-group">
             <label for="modal_shelf_minimum_threshold" class="col-form-label">Minimum:</label>
-            <input type="number" class="form-control" id="modal_shelf_minimum_threshold">
+            <input type="number" class="form-control" id="modal_shelf_minimum_threshold" name="modal_shelf_minimum_threshold">
           </div>
           <div class="form-group">
             <label for="modal_shelf_maximum_threshold" class="col-form-label">Maximum:</label>
-            <input type="number" class="form-control" id="modal_shelf_maximum_threshold">
+            <input type="number" class="form-control" id="modal_shelf_maximum_threshold" name="modal_shelf_maximum_threshold">
           </div>
           <div class="form-group">
-            <input type="hidden" class="form-control" id="modal_shelf_id">
+            <input type="hidden" class="form-control" id="modal_shelf_id" name="modal_shelf_id">
           </div>
         </form>
       </div>

--- a/views/partials/shelves_edit_modal.hbs
+++ b/views/partials/shelves_edit_modal.hbs
@@ -1,21 +1,22 @@
-<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+<div class="modal fade" id="shelvesEditModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+        <h5 class="modal-title" id="exampleModalLongTitle">Adjust Shelf Capacity</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">
         <form>
+            Shelf Thresholds:
           <div class="form-group">
-            <label for="recipient-name" class="col-form-label">Recipient:</label>
-            <input type="text" class="form-control" id="recipient-name">
+            <label for="shelf_minimum_threshold" class="col-form-label">Minimum:</label>
+            <input type="number" class="form-control" id="shelf_minimum_threshold">
           </div>
           <div class="form-group">
-            <label for="message-text" class="col-form-label">Message:</label>
-            <textarea class="form-control" id="message-text"></textarea>
+            <label for="shelf_maximum_threshold" class="col-form-label">Maximum:</label>
+            <input type="number" class="form-control" id="shelf_maximum_threshold">
           </div>
         </form>
       </div>
@@ -26,3 +27,5 @@
     </div>
   </div>
 </div>
+
+<script src="/scripts/shelves_edit.js"></script>


### PR DESCRIPTION
Users can now click on the row to edit the shelf thresholds for that inventory item. Input is taken using a modal (sort of like a pop-up) and data is validated before being sent to the database.

Minor Changes:
Added a standard to the README for making your own classes.